### PR TITLE
LPAL-967 fix build

### DIFF
--- a/feedbackapi/docker/app/Dockerfile
+++ b/feedbackapi/docker/app/Dockerfile
@@ -8,13 +8,13 @@ WORKDIR /feedbackapi
 RUN apk update
 
 #i git is required to pip install feedback api as it has a depedency on a git repo
-RUN apk add git
+RUN apk add git build-base
 
 COPY feedbackapi .
 
 RUN cd /feedbackapi && pip install -e .
 
-RUN apk del git
+RUN apk del git build-base
 
 USER opgfeedbackuser
 

--- a/feedbackdb/docker/app/Dockerfile
+++ b/feedbackdb/docker/app/Dockerfile
@@ -2,11 +2,15 @@ FROM python:3.8-alpine
 
 RUN apk upgrade
 
+RUN apk add build-base
+
 RUN pip install awscli psycopg2-binary sqlalchemy alembic
 
 RUN alembic init alembic
 
 COPY feedbackdb/ /app/
+
+RUN apk del build-base
 
 WORKDIR /app
 


### PR DESCRIPTION
install build-base to get gcc now that its been removed from underlying python image